### PR TITLE
Move some import* functions to correct submodule

### DIFF
--- a/src/Binaryen.hs
+++ b/src/Binaryen.hs
@@ -79,14 +79,6 @@ foreign import ccall unsafe "BinaryenSetOneCallerInlineMaxSize"
   setOneCallerInlineMaxSize ::
     Index -> IO ()
 
-foreign import ccall unsafe "BinaryenGlobalImportGetBase"
-  globalImportGetBase ::
-    Global -> IO (Ptr CChar)
-
-foreign import ccall unsafe "BinaryenEventImportGetBase"
-  eventImportGetBase ::
-    Event -> IO (Ptr CChar)
-
 foreign import ccall unsafe "BinaryenSetAPITracing"
   setAPITracing ::
     CInt -> IO ()

--- a/src/Binaryen/Event.hs
+++ b/src/Binaryen/Event.hs
@@ -33,3 +33,7 @@ foreign import ccall unsafe "BinaryenEventGetResults"
 foreign import ccall unsafe "BinaryenEventImportGetModule"
   importGetModule ::
     Event -> IO (Ptr CChar)
+
+foreign import ccall unsafe "BinaryenEventImportGetBase"
+  eventImportGetBase ::
+    Event -> IO (Ptr CChar)

--- a/src/Binaryen/Global.hs
+++ b/src/Binaryen/Global.hs
@@ -34,3 +34,7 @@ foreign import ccall unsafe "BinaryenGlobalGetInitExpr"
 foreign import ccall unsafe "BinaryenGlobalImportGetModule"
   importGetModule ::
     Global -> IO (Ptr CChar)
+
+foreign import ccall unsafe "BinaryenGlobalImportGetBase"
+  globalImportGetBase ::
+    Global -> IO (Ptr CChar)


### PR DESCRIPTION
They were previously exported from `Binaryen` for `Event` and
`Global`. This wasn't consistent with what we did for `Function`.