### PR TITLE
Pin version of Nixpkgs

### DIFF
--- a/nixpkgs.nix
+++ b/nixpkgs.nix
@@ -1,0 +1,9 @@
+let
+  # 2020-04-03
+  rev = "4dc8447c55fe5262bad1019121a8e6d3f9e1e71f";
+  sha256 = "113961iip25h3visfpszrnvwwclkvkgj4x9c7inlh90vcfrk325p";
+in
+import (fetchTarball {
+  inherit sha256;
+  url = "https://github.com/NixOS/nixpkgs/archive/${rev}.tar.gz";
+})

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,5 +1,6 @@
 resolver: lts-15.7
 
 nix:
+  path: [nixpkgs=./nixpkgs.nix]
   packages:
     - binaryen


### PR DESCRIPTION
To make sure builds are reproducible and that we are pulling in the
right version of Binaryen.